### PR TITLE
R and R: Create getRatings function that can be passed as prop to rest of App

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,7 +31,6 @@ import getRatings from './components/rating-reviews/controllers/getRatings.jsx';
         <h1>Hello World!</h1>
         {/* <ProductsInfo productId={productId}/> */}
         <RelatedProducts productId={productId}/>
-        <RatingReviews productId={productId}/>
         <QuestionAnswers productId={productId}/>
         <RatingReviews productId={productId} getRatings={getRatings}/>
       </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,8 @@ import RelatedProducts from './components/related-products/RelatedProducts.jsx';
 import RatingReviews from './components/rating-reviews/RatingReviews.jsx';
 import QuestionAnswers from './components/question-answers/QuestionAnswers.jsx';
 
+import getRatings from './components/rating-reviews/controllers/getRatings.jsx';
+
 
   // useEffect(() => {
   //   axios.get(`products/${id}`)
@@ -31,6 +33,7 @@ import QuestionAnswers from './components/question-answers/QuestionAnswers.jsx';
         <RelatedProducts productId={productId}/>
         <RatingReviews productId={productId}/>
         <QuestionAnswers productId={productId}/>
+        <RatingReviews productId={productId} getRatings={getRatings}/>
       </div>
     )
   }

--- a/src/Components/rating-reviews/controllers/getRatings.jsx
+++ b/src/Components/rating-reviews/controllers/getRatings.jsx
@@ -17,7 +17,11 @@ const getRatings = (product_id, cssClass) => {
     const metaResults = {};
     metaResults.totalReviews = totalReviews.toString();
     metaResults.meanRating = meanRating.toString();
-    metaResults.RatingStars = <p className={cssClass}>Stars still in dev, average rating is {meanRating}</p>;
+    metaResults.RatingStars = <p
+        className={"stars" + (cssClass ? " " + cssClass : "")}
+      >
+        Stars still in dev, average rating is {meanRating}
+      </p>;
     metaResults.allMetaData = metaData;
     return metaResults;
   }).catch((err) => {
@@ -25,7 +29,7 @@ const getRatings = (product_id, cssClass) => {
     const errResults = {};
     errResults.totalReviews = 'N/A';
     errResults.meanRating = 'N/A';
-    errResults.RatingStars = <p className={cssClass}>Unable to show rating</p>;
+    errResults.RatingStars = <p className={"stars " + cssClass}>Unable to show rating</p>;
     errResults.allMetaData = {};
     return errResults;
   })

--- a/src/Components/rating-reviews/controllers/getRatings.jsx
+++ b/src/Components/rating-reviews/controllers/getRatings.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { getReviewsMetaData } from "../models/reviewsModels.js";
+
+const getRatings = (product_id, cssClass) => {
+  return getReviewsMetaData(product_id)
+  .then((res)=>{
+    const metaData = res.data;
+    //calculate average rating
+    const { ratings }  = metaData;
+    let [totalStars, totalReviews] = [0, 0];
+    for (let key in ratings) {
+      totalStars += Number(ratings[key]) * Number(key);
+      totalReviews += Number(ratings[key]);
+    }
+    const meanRating = Math.round((totalStars / totalReviews) * 10) / 10;
+    //create results object
+    const metaResults = {};
+    metaResults.totalReviews = totalReviews.toString();
+    metaResults.meanRating = meanRating.toString();
+    metaResults.RatingStars = <p className={cssClass}>Stars still in dev, average rating is {meanRating}</p>;
+    metaResults.allMetaData = metaData;
+    return metaResults;
+  }).catch((err) => {
+    console.log('Error getting metaData: ', err);
+    const errResults = {};
+    errResults.totalReviews = 'N/A';
+    errResults.meanRating = 'N/A';
+    errResults.RatingStars = <p className={cssClass}>Unable to show rating</p>;
+    errResults.allMetaData = {};
+    return errResults;
+  })
+};
+
+export default getRatings;

--- a/src/components/rating-reviews/RatingReviews.jsx
+++ b/src/components/rating-reviews/RatingReviews.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { lazy, Suspense, useState } from "react";
 const RatingBreakdown = lazy(() => import("./components/RatingBreakdown.jsx"));
 
-const RatingReviews = ( {product_id} ) => {
+const RatingReviews = ( { productId, getRatings} ) => {
 
   // Adds suspense fallback to component provided until it is available
   const suspenseView = (component) => (
@@ -11,11 +11,14 @@ const RatingReviews = ( {product_id} ) => {
     </Suspense>
   );
 
-  const ratingBreakdown = <RatingBreakdown />
+  const ratingBreakdown = <RatingBreakdown
+    getRatings={getRatings}
+    productId={productId}
+  />;
 
 
   return(
-  <section className="r-and-r">
+  <section className="r-and-r" id="r-and-r">
     <h2>RATINGS AND REVIEWS</h2>
     {suspenseView(ratingBreakdown)}
   </section>

--- a/src/components/rating-reviews/RatingReviews.jsx
+++ b/src/components/rating-reviews/RatingReviews.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { lazy, Suspense, useState } from "react";
 const RatingBreakdown = lazy(() => import("./components/RatingBreakdown.jsx"));
 
-const RatingReviews = ( { productId, getRatings} ) => {
+const RatingReviews = ({ productId, getRatings }) => {
 
   // Adds suspense fallback to component provided until it is available
   const suspenseView = (component) => (

--- a/src/components/rating-reviews/components/RatingBreakdown.jsx
+++ b/src/components/rating-reviews/components/RatingBreakdown.jsx
@@ -1,15 +1,16 @@
 import React, { useState, useEffect } from "react";
-import { getReviewsMetaData } from "../models/reviewsModels.js";
 
 const RatingBreakdown = ({ productId, getRatings }) => {
   const [ratingStars, setRatingStars] = useState(<p className={"stars"}>Loading</p>);
 
   useEffect(()=> {
-    getRatings(productId)
-    .then((metaResults) => {
-      console.log('Got results from promise: ', metaResults);
-      setRatingStars(metaResults.RatingStars);
-    })
+    if(getRatings) {
+      getRatings(productId)
+      .then((metaResults) => {
+        console.log('Results from calling getRatings on productId: ', metaResults);
+        setRatingStars(metaResults.RatingStars);
+      })
+    }
   }, []);
 
 

--- a/src/components/rating-reviews/components/RatingBreakdown.jsx
+++ b/src/components/rating-reviews/components/RatingBreakdown.jsx
@@ -1,12 +1,16 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import { getReviewsMetaData } from "../models/reviewsModels.js";
 
 const RatingBreakdown = ({ productId, getRatings }) => {
-  const [ratingStars, setRatingStars] = useState(<p>Loading</p>);
-  // getRatings(productId)
-  //   .then((metaResults) => {
-  //     console.log('Got results from promise: ', metaResults);
-  //     setRatingStars(metaResults.RatingStars);
-  // })
+  const [ratingStars, setRatingStars] = useState(<p className={"stars"}>Loading</p>);
+
+  useEffect(()=> {
+    getRatings(productId)
+    .then((metaResults) => {
+      console.log('Got results from promise: ', metaResults);
+      setRatingStars(metaResults.RatingStars);
+    })
+  }, []);
 
 
   return(

--- a/src/components/rating-reviews/components/RatingBreakdown.jsx
+++ b/src/components/rating-reviews/components/RatingBreakdown.jsx
@@ -1,10 +1,17 @@
 import React, { useState } from "react";
 
-const RatingBreakdown = ( {product_id} ) => {
+const RatingBreakdown = ({ productId, getRatings }) => {
+  const [ratingStars, setRatingStars] = useState(<p>Loading</p>);
+  // getRatings(productId)
+  //   .then((metaResults) => {
+  //     console.log('Got results from promise: ', metaResults);
+  //     setRatingStars(metaResults.RatingStars);
+  // })
+
 
   return(
   <aside className="rating-breakdown">
-    <p>Rating breakdown placeholder</p>
+    {ratingStars}
   </aside>
   );
 };


### PR DESCRIPTION
Created a getRatings function that is imported to App.jsx so that it can be passed as a prop to any module that needs it.

getRatings takes an argument of any product_id string and a second optional argument of a css class name of a string and returns a promise for an object  with the following properties:
```
{
  totalReviews: <a string with the number of total reviews for the product or "N/A" if API request failed>,
  meanRating: <a string with the mean (average) of all ratings, rounded to 1 decimal point, for the product or "N/A" if API request failed>,
  RatingStars: <a react element (currently paragraph) with css class named "stars" plus the css class name passed to the function if applicable. The elements display is still in development but has a placeholder that shows some text with the mean of ratings, or 'Unable to show rating' if API request failed>,
  allMetaData: <an object containing all reviews meta data for the product, or an empty object if API request failed>
}
```

Also added a UseEffect, which uses the getRatings function, to add the stars element for current product_id in RatingBreakdown component.