### PR TITLE
R&R: make stars render correctly in react RatingStars element generated by getRatings render prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "Atelier",
       "version": "1.0",
       "dependencies": {
+        "@heroicons/react": "^2.1.1",
         "axios": "^1.6.7",
         "dotenv": "^16.4.5",
         "express": "^4.18.2",
@@ -1842,6 +1843,14 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.1.1.tgz",
+      "integrity": "sha512-JyyN9Lo66kirbCMuMMRPtJxtKJoIsXKS569ebHGGRKbl8s4CtUfLnyKJxteA+vIKySocO4s1SkTkGS4xtG/yEA==",
+      "peerDependencies": {
+        "react": ">= 16"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -14449,6 +14458,12 @@
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true
+    },
+    "@heroicons/react": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.1.1.tgz",
+      "integrity": "sha512-JyyN9Lo66kirbCMuMMRPtJxtKJoIsXKS569ebHGGRKbl8s4CtUfLnyKJxteA+vIKySocO4s1SkTkGS4xtG/yEA==",
+      "requires": {}
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "(UNSUPPORTED BY DEFAULT; see webpack.config.js for more info) client-dev:hot": "npx webpack serve --hot --open"
   },
   "dependencies": {
+    "@heroicons/react": "^2.1.1",
     "axios": "^1.6.7",
     "dotenv": "^16.4.5",
     "express": "^4.18.2",

--- a/src/Components/rating-reviews/controllers/getRatings.jsx
+++ b/src/Components/rating-reviews/controllers/getRatings.jsx
@@ -1,24 +1,32 @@
 import React from "react";
 import { getReviewsMetaData } from "../models/reviewsModels.js";
-import { StarIcon as SolidStar } from '@heroicons/react/24/solid';
-import { StarIcon as OutlineStar } from '@heroicons/react/24/outline';
+import { StarIcon as SolidStar } from "@heroicons/react/24/solid";
+import { StarIcon as OutlineStar } from "@heroicons/react/24/outline";
 
 
 const renderStars = (meanRating, cssClass) => {
-  const solidStars = (n) => (
-    [...(new Array(n))].map((i) => (
-      <span position="relative" style={{width: "1em"}}>
-        <SolidStar style={{height: "1em", width: "1em", position: "relative"}}/>
-      </span>
-    ))
-  );
-  const outlineStars = (n) => (
-    [...(new Array(n))].map((i) => (
-      <span position="relative" style={{width: "1em"}}>
-        <OutlineStar style={{height: "1em", width: "1em"}}/>
-      </span>
-    ))
-  );
+  const solidStars = (n) => {
+    let key = 0;
+    return [...(new Array(n))].map((i) => {
+      key ++;
+      return (
+        <span position="relative" key={key} style={{width: "1em"}}>
+          <SolidStar style={{height: "1em", width: "1em", position: "relative"}}/>
+        </span>
+      );
+    });
+  };
+  const outlineStars = (n) => {
+    let key = 0;
+    return [...(new Array(n))].map((i) => {
+      key ++;
+      return (
+        <span position="relative" key={key} style={{width: "1em"}}>
+          <OutlineStar style={{height: "1em", width: "1em", position: "relative"}}/>
+        </span>
+      );
+    });
+  };
   const partialStar = (decimal) => {
     //width of solid portion of partial star, note: 0.17em (or less) is empty and 0.83em is full
     const width = (0.17 + (Math.round(decimal * 4) / 4) * 0.66) + 'em';

--- a/src/Components/rating-reviews/controllers/getRatings.jsx
+++ b/src/Components/rating-reviews/controllers/getRatings.jsx
@@ -1,5 +1,52 @@
 import React from "react";
 import { getReviewsMetaData } from "../models/reviewsModels.js";
+import { StarIcon as SolidStar } from '@heroicons/react/24/solid';
+import { StarIcon as OutlineStar } from '@heroicons/react/24/outline';
+
+
+const renderStars = (meanRating, cssClass) => {
+  const solidStars = (n) => (
+    [...(new Array(n))].map((i) => (
+      <span position="relative" style={{width: "1em"}}>
+        <SolidStar style={{height: "1em", width: "1em", position: "relative"}}/>
+      </span>
+    ))
+  );
+  const outlineStars = (n) => (
+    [...(new Array(n))].map((i) => (
+      <span position="relative" style={{width: "1em"}}>
+        <OutlineStar style={{height: "1em", width: "1em"}}/>
+      </span>
+    ))
+  );
+  const partialStar = (decimal) => {
+    //width of solid portion of partial star, note: 0.17em (or less) is empty and 0.83em is full
+    const width = (0.17 + (Math.round(decimal * 4) / 4) * 0.66) + 'em';
+    return (
+      <span position="relative" style={{
+        display: "inline-flex",
+        width: "1em",
+        position: "relative",
+        textAlign: "left"
+      }}>
+      <span style={{width: width, overflow: "hidden", position: "absolute"}}>
+        <SolidStar style={{height: "1em", width: "1em"}}/>
+      </span>
+      <span>
+        <OutlineStar style={{height: "1em", width: "1em"}}/>
+      </span>
+    </span>
+    )
+  }
+
+  return (
+  <span className={"stars" + (cssClass ? " " + cssClass : "")}>
+    {solidStars(Math.floor(meanRating))}
+    {partialStar(meanRating - Math.floor(meanRating))}
+    {outlineStars(5 - Math.ceil(meanRating))}
+  </span>)
+}
+
 
 const getRatings = (product_id, cssClass) => {
   return getReviewsMetaData(product_id)
@@ -17,11 +64,7 @@ const getRatings = (product_id, cssClass) => {
     const metaResults = {};
     metaResults.totalReviews = totalReviews.toString();
     metaResults.meanRating = meanRating.toString();
-    metaResults.RatingStars = <p
-        className={"stars" + (cssClass ? " " + cssClass : "")}
-      >
-        Stars still in dev, average rating is {meanRating}
-      </p>;
+    metaResults.RatingStars = <>{renderStars(meanRating, cssClass)}</>;
     metaResults.allMetaData = metaData;
     return metaResults;
   }).catch((err) => {
@@ -29,7 +72,11 @@ const getRatings = (product_id, cssClass) => {
     const errResults = {};
     errResults.totalReviews = 'N/A';
     errResults.meanRating = 'N/A';
-    errResults.RatingStars = <p className={"stars " + cssClass}>Unable to show rating</p>;
+    errResults.RatingStars = (
+      <span className={"stars" + (cssClass ? " " + cssClass : "")}>
+        Unable to show rating
+      </span>
+    );
     errResults.allMetaData = {};
     return errResults;
   })


### PR DESCRIPTION
Add star icons and make stars render correctly in RatingStars react element included in object promised by the getRatings render prop function.

I also changed RatingStars element to be a span element instead of a paragraph (p).

Note that I added heroicons to our package.json to be able to include the icons.